### PR TITLE
Fix test infrastructure

### DIFF
--- a/extras/Makefile
+++ b/extras/Makefile
@@ -1,0 +1,81 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Author:      Andreas Kuster, <kustera@ethz.ch>
+# Description: Targets for simulation, linting and synthesis.
+
+SHELL := /bin/bash
+
+includes := axi/include \
+			register_interface/include \
+			common_cells/include
+list_includes := $(foreach dir, ${includes}, --incdir=../src/$(dir))
+
+packages := common_cells/src/cf_math_pkg.sv \
+			axi/src/axi_pkg.sv \
+			register/io_pmp_reg_pkg.sv \
+			pmp/include/riscv.sv
+list_packages := $(foreach dir, ${packages}, ../src/$(dir))
+
+sources :=  common_cells/src/lzc.sv \
+			common_cells/src/spill_register_flushable.sv \
+			common_cells/src/spill_register.sv \
+			common_cells/src/deprecated/fifo_v2.sv \
+			common_cells/src/fifo_v3.sv \
+			common_cells/src/stream_register.sv \
+			common_cells/src/stream_arbiter_flushable.sv \
+			common_cells/src/stream_arbiter.sv \
+			common_cells/src/delta_counter.sv \
+			common_cells/src/counter.sv \
+			common_cells/src/id_queue.sv \
+			common_cells/src/rr_arb_tree.sv \
+			common_cells/src/onehot_to_bin.sv \
+			axi/src/axi_intf.sv \
+			axi/src/axi_err_slv.sv \
+			axi/src/axi_demux.sv \
+			axi/src/axi_atop_filter.sv \
+			axi/src/axi_burst_splitter.sv \
+			axi/src/axi_to_axi_lite.sv \
+			axi/src/axi_cut.sv \
+			register/io_pmp_reg_top.sv \
+			register_interface/src/axi_to_reg.sv \
+			register_interface/src/axi_lite_to_reg.sv \
+			register_interface/vendor/lowrisc_opentitan/src/prim_subreg.sv \
+			register_interface/vendor/lowrisc_opentitan/src/prim_subreg_arb.sv \
+			register_interface/vendor/lowrisc_opentitan/src/prim_subreg_ext.sv \
+			register_interface/vendor/lowrisc_opentitan/src/prim_subreg_shadow.sv \
+			connector/axi_master_connector.sv \
+			connector/axi_slave_connector.sv \
+			connector/reg_cut.sv \
+			pmp/pmp_entry.sv \
+			pmp/pmp.sv \
+			axi_io_pmp.sv \
+			../tb/dut.sv
+list_sources := $(foreach dir, ${sources}, ../src/$(dir))
+
+
+format:
+	./format.sh
+
+
+install_sv2v:
+ifeq (,$(wildcard sv2v-Linux.zip))
+	wget https://github.com/zachjs/sv2v/releases/download/v0.0.9/sv2v-Linux.zip
+	unzip sv2v-Linux.zip
+endif
+
+
+sv2v:
+	./sv2v-Linux/sv2v --define=VERILATOR $(list_includes) $(list_packages) $(list_sources) --write iopmp.v
+
+
+clean:
+	rm -rf sv2v-Linux/
+	rm iopmp.v sv2v-Linux.zip

--- a/extras/format.sh
+++ b/extras/format.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Author:      Andreas Kuster, <kustera@ethz.ch>
+# Description: Formatting / linting of all source files, including Verilog/SystemVerilog.
+
+# clang formatting
+echo "Format c/cpp/h files"
+find . -type d \( -name *venv* -o -name *common_cells* -o -name *axi* -o -name *register_interface* -o -name *OpenROAD-flow-scripts* -o -name *verible-v0.0-1897-gbe7e2250* \) -prune -false -o -name ".c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" | xargs -I {} clang-format -i {}
+
+# install verible
+if [ ! -f "verible.tar.gz" ]; then
+  echo "Install verible.."
+  wget https://github.com/chipsalliance/verible/releases/download/v0.0-1897-gbe7e2250/verible-v0.0-1897-gbe7e2250-Ubuntu-20.04-focal-x86_64.tar.gz -O verible.tar.gz
+  tar -xzf verible.tar.gz
+  fi
+export PATH=./verible-v0.0-1897-gbe7e2250/bin/:$PATH
+
+# format all verilog files
+echo "Format verilog files.."
+find . -type d \( -name *venv* -o -name *common_cells* -o -name *axi* -o -name *register_interface* -o -name *OpenROAD-flow-scripts* -o -name *verible-v0.0-1897-gbe7e2250* \) -prune -false -o -name ".svh" -o -name "*.sv" -o -name "*.v" | xargs verible-verilog-format -inplace
+
+echo "All done."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wheel==0.37.1
 cocotb==1.6.1
 cocotb-bus==0.1.1
-git+https://github.com/andreaskuster/cocotb-test@4beff202c36313957e2e558888bff92d0818c79b # fixes coverage support, PR pending (https://github.com/themperek/cocotb-test/pull/172)
+cocotb-test==0.2.0
 cocotbext-axi==0.1.18
 gprof2dot==2021.2.21
 bitarray==2.3.5
@@ -10,5 +10,5 @@ hjson==3.0.2
 pyyaml==6.0.0
 pytest==6.2.5
 pytest-xdist==2.5.0
-pydevd-pycharm~=213.6777.50
-numpy==1.22.1
+pydevd-pycharm~=232.8660.49
+numpy==1.25.1

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -30,6 +30,9 @@ source venv/bin/activate
 python3 -m pip install wheel
 python3 -m pip install -r requirements.txt
 
+# patch verilator for g++-11
+sudo sh -c "sed -i '29s/^/#include <limits>\n/' /usr/share/verilator/include/verilated.cpp"
+
 # setup questasim
 QUESTA_ENV=/opt/questasim/setup.sh
 if [ -f "$QUESTA_ENV" ]; then

--- a/ubuntu_requirements.txt
+++ b/ubuntu_requirements.txt
@@ -4,3 +4,4 @@ verilator-4.106
 graphviz
 gtkwave
 clang-format
+g++


### PR DESCRIPTION
This PR restores the testing infrastructure for the cocotb based co-simulation framework, supporting Icarus, Verilator and Questa to test the AXI IO-PMP module functionality extensively.

Changes include:
- Add missing files from the original repo (Makefile and linting related scripts)
- Upgrade Python dependencies (cocotb-test has been fixed in the meantime)
- Ensure Ubuntu compatibility